### PR TITLE
Remove dependency `xdg-user-dirs`

### DIFF
--- a/swayshot.sh
+++ b/swayshot.sh
@@ -41,16 +41,16 @@ make_screenshot() {
 }
 
 copy_to_clipboard() {
-	if type wl-copy >/dev/null  2>&1; then
+	if command-v wl-copy >/dev/null  2>&1; then
 		if [ -z "$SWAYSHOT_WL_COPY_FILE" ]; then
 			printf "%s" "$1" | wl-copy
 		else
 			wl-copy < "$SCREENSHOT_FULLNAME"
 		fi
-	elif type xsel >/dev/null  2>&1; then
+	elif command-v xsel >/dev/null  2>&1; then
 		printf "%s" "$1" | xsel --clipboard
 		unset SWAYSHOT_WL_COPY_FILE
-	elif type xclip &>/dev/null; then
+	elif command-v xclip >/dev/null 2>&1; then
 		printf "%s" "$1" | xclip -selection clipboard
 		unset SWAYSHOT_WL_COPY_FILE
 	else
@@ -59,14 +59,14 @@ copy_to_clipboard() {
 }
 
 show_message() {
-	if type notify-send >/dev/null  2>&1; then
+	if command-v notify-send >/dev/null  2>&1; then
 		notify-send --expire-time=3000 --category=screenshot --icon="$2" "$3" "$1"
 	fi
 }
 
 upload_screenshot() {
 	if [ -f "$1" ]; then
-		if type curl >/dev/null  2>&1; then
+		if command-v curl >/dev/null  2>&1; then
 			curl -s -F "file=@\"$1\"" https://0x0.st
 		fi
 	fi

--- a/swayshot.sh
+++ b/swayshot.sh
@@ -14,7 +14,7 @@ if [ -f ~/.config/swayshot.sh ]; then
 fi
 
 if [ -z $SWAYSHOT_SCREENSHOTS ]; then
-	SWAYSHOT_SCREENSHOTS=$(xdg-user-dir PICTURES)
+  SWAYSHOT_SCREENSHOTS="$(grep '^XDG_PICTURES_DIR=' "$XDG_CONFIG_HOME/user-dirs.dirs" | cut -d '=' -f 2 | tr -d '"')"
 fi
 
 SCREENSHOT_TIMESTAMP=$(date "+${SWAYSHOT_DATEFMT:-%F_%H-%M-%S_%N}")

--- a/swayshot.sh
+++ b/swayshot.sh
@@ -2,7 +2,7 @@
 # Screenshot helper for sway.
 # Copyright 2017,2019,2021 Witalij Berdinskich.
 
-if [ -z $WAYLAND_DISPLAY ]; then
+if [ -z "$WAYLAND_DISPLAY" ]; then
 	(>&2 echo Wayland is not running)
 	exit 1
 fi
@@ -13,7 +13,7 @@ if [ -f ~/.config/swayshot.sh ]; then
 	. ~/.config/swayshot.sh
 fi
 
-if [ -z $SWAYSHOT_SCREENSHOTS ]; then
+if [ -z "$SWAYSHOT_SCREENSHOTS" ]; then
   SWAYSHOT_SCREENSHOTS="$(grep '^XDG_PICTURES_DIR=' "$XDG_CONFIG_HOME/user-dirs.dirs" | cut -d '=' -f 2 | tr -d '"')"
 fi
 
@@ -42,7 +42,7 @@ make_screenshot() {
 
 copy_to_clipboard() {
 	if type wl-copy >/dev/null  2>&1; then
-		if [ -z $SWAYSHOT_WL_COPY_FILE ]; then
+		if [ -z "$SWAYSHOT_WL_COPY_FILE" ]; then
 			printf "%s" "$1" | wl-copy
 		else
 			wl-copy < "$SCREENSHOT_FULLNAME"
@@ -81,16 +81,16 @@ fi
 case "$2" in
 	upload)
 		SCREENSHOT_LOCATOR=$(upload_screenshot "$SCREENSHOT_FULLNAME")
-		if [ -z $SCREENSHOT_LOCATOR ]; then
+		if [ -z "$SCREENSHOT_LOCATOR" ]; then
 			copy_to_clipboard "$SCREENSHOT_FULLNAME"
 			show_message "$SCREENSHOT_FULLNAME" document-save "Screenshot path"
-			if [ ! -z $SWAYSHOT_WL_COPY_FILE ]; then
+			if [ -n "$SWAYSHOT_WL_COPY_FILE" ]; then
 				show_message "Screenshot was copied to clipboard.\\nFeel free to paste it." "$SCREENSHOT_FULLNAME" "Screenshot image"
 			fi
 		else
 			copy_to_clipboard "$SCREENSHOT_LOCATOR"
 			show_message "$SCREENSHOT_LOCATOR" document-send "Screenshot URL"
-			if [ ! -z $SWAYSHOT_WL_COPY_FILE ]; then
+			if [ -n "$SWAYSHOT_WL_COPY_FILE" ]; then
 				show_message "Screenshot was copied to clipboard.\\nFeel free to paste it." "$SCREENSHOT_FULLNAME" "Screenshot image"
 			fi
 		fi
@@ -98,7 +98,7 @@ case "$2" in
 	*)
 		copy_to_clipboard "$SCREENSHOT_FULLNAME"
 		show_message "$SCREENSHOT_FULLNAME" document-save "Screenshot path"
-		if [ ! -z $SWAYSHOT_WL_COPY_FILE ]; then
+		if [ -n "$SWAYSHOT_WL_COPY_FILE" ]; then
 			show_message "Screenshot was copied to clipboard.\\nFeel free to paste it." "$SCREENSHOT_FULLNAME" "Screenshot image"
 		fi
 esac


### PR DESCRIPTION
Hey, 

Drafting this PR to see whether you'd be open to removing the `xdg-user-dir` dependency. 
It looks like the [the project](https://gitlab.freedesktop.org/xdg/xdg-user-dirs) is unmaintained.

The manpages suggests we can simply check for XDG_CONFIG_HOME if the user is already using xdg-user-dirs
```man
ENVIRONMENT
       The XDG_CONFIG_HOME environment variable determines where the user-dirs.dirs file is located.
```

Do you have any problems or concerns with this?
Thanks.