### PR TITLE
add an option to avoid the notification

### DIFF
--- a/swayshot.sh
+++ b/swayshot.sh
@@ -65,8 +65,10 @@ copy_to_clipboard() {
 }
 
 show_message() {
-	if command -v notify-send >/dev/null  2>&1; then
-		notify-send --expire-time=3000 --category=screenshot --icon="$2" "$3" "$1"
+	if [ -z $SWAYSHOT_HIDE_NOTIFICATION ]; then
+		if command -v notify-send >/dev/null 2>&1; then
+			notify-send --expire-time=3000 --category=screenshot --icon="$2" "$3" "$1"
+		fi
 	fi
 }
 


### PR DESCRIPTION
This adds the ability to avoid the notification by setting the SWAYSHOT_HIDE_NOTIFICATION environment variable.

I think there could be many use cases, but I personally needed this option because I'm using swayshot together with an OCR software to translate the content I'm screenshoting, and since the OCR software spits out the translation using notify-send, I ended up getting two notifications.

of course the notification will still appear by default.